### PR TITLE
Skip replacing a valid token with a no-scopes token during login

### DIFF
--- a/backend/src/Service/Account.php
+++ b/backend/src/Service/Account.php
@@ -160,10 +160,18 @@ class Account
             $this->objectManager->persist($esiToken);
         }
         if (is_numeric($token->getExpires()) && is_string($token->getRefreshToken())) {
-            $esiToken->setAccessToken($token->getToken());
-            $esiToken->setExpires($token->getExpires());
-            $esiToken->setRefreshToken($token->getRefreshToken());
-            $esiToken->setLastChecked(new \DateTime());
+            if (count($eveAuth->getScopes()) === 0 && $esiToken->getValidToken() === true) {
+                // Avoid replacing an existing valid token (i.e. one with at least one scope) with one that has no scopes
+                // This prevents players that login with the no-scopes login (commonly intended for allies) from bricking their groups
+                $this->log->debug(
+                    "Account::updateAndStoreCharacterWithPlayer: Skipped updating token for {$char->getId()} because it would replace a valid token with a no-scopes token.",
+                );
+            } else {
+                $esiToken->setAccessToken($token->getToken());
+                $esiToken->setExpires($token->getExpires());
+                $esiToken->setRefreshToken($token->getRefreshToken());
+                $esiToken->setLastChecked(new \DateTime());
+            }
         } else {
             $char->removeEsiToken($esiToken);
             $this->objectManager->remove($esiToken);

--- a/backend/tests/Unit/Service/AccountTest.php
+++ b/backend/tests/Unit/Service/AccountTest.php
@@ -307,6 +307,37 @@ class AccountTest extends TestCase
         $this->assertSame('name corp', $character->getCorporation()->getName());
     }
 
+    public function testUpdateAndStoreCharacterWithPlayer_DoesNotReplaceValidTokenWithNoScopesToken()
+    {
+        $eveLogin = (new EveLogin())->setName(EveLogin::NAME_DEFAULT);
+        // Test against valid token (i.e. it would have scopes)
+        $existingToken = (new EsiToken())->setEveLogin($eveLogin)
+            ->setRefreshToken('rt')->setAccessToken('at-existing-token')->setExpires(123)->setValidToken(true);
+        $corp = (new Corporation())->setId(1);
+        $player = (new Player())->setName('p-name');
+        $char = (new Character())->setName('c-name')->setId(12)->setPlayer($player)->setCorporation($corp);
+        $existingToken->setCharacter($char);
+        $this->om->persist($eveLogin);
+        $this->om->persist($existingToken);
+        $this->om->persist($corp);
+        $this->om->persist($player);
+        $this->om->persist($char);
+        $this->om->flush();
+
+        // Pass in new token with no scopes
+        $token = Helper::generateToken([]);
+        $result = $this->service->updateAndStoreCharacterWithPlayer(
+            $char,
+            new EveAuthentication(100, '', '', new AccessToken(['access_token' => $token[0]])),
+        );
+        $this->assertTrue($result);
+        $this->om->clear();
+
+        // We expect the token to still be the initial valid token, not the no-scopes token
+        $updatedCharacter = $this->charRepo->find(12);
+        $this->assertSame('at-existing-token', $updatedCharacter->getEsiToken(EveLogin::NAME_DEFAULT)->getAccessToken());
+    }
+
     public function testUpdateAndStoreCharacterWithPlayer_NoToken()
     {
         $eveLogin = (new EveLogin())->setName(EveLogin::NAME_DEFAULT);

--- a/frontend/src/pages/Administration/SystemSettings--Features.vue
+++ b/frontend/src/pages/Administration/SystemSettings--Features.vue
@@ -98,11 +98,7 @@
             Login URL:
             <a :href="`${backendHost}/login/${loginNames.noScopes}`">{{ backendHost }}/login/{{ loginNames.noScopes }}</a>
             <br>
-            This login URL does not require any ESI scopes. If used it will disable groups for the player account
-            if the "Groups Deactivation" feature above is enabled and the player has a character in one of the
-            configured alliances or corporations, unless the
-            <!--suppress HtmlUnknownAnchorTarget --> <a href="#PlayerManagement">account status</a>
-            is "manually managed".
+            This login URL does not require any ESI scopes.
         </p>
 
         <hr>


### PR DESCRIPTION
## Summary

Here's a common situation:
1. Alliance has both scoped login (for members) and non-scoped login (for guests, allies, whatever) - e.g. https://account.bravecollective.com/ - with both linked on the Neucore home page
2. Member with scoped tokens goes to login
3. They aren't paying attention and login with the no-scopes login
4. Their token gets hosed, and this breaks their groups, has corp leadership yelling at them, etc

This PR attempts to fix this common mistake by not replacing valid tokens with the new token from login, if that token has no scopes (a valid token always has at least one scope, as neucore treats no-scope tokens as invalid).

In theory this could be more elaborate (e.g. see if the new token's scopes are a subset of the existing one), but I figure specifically checking for no scopes is the simplest solution and poses very little risk of introducing a bug or other collateral damage.

## Testing

### Manual

Setup Neucore with the no-scopes login enabled, and use it to attempt to login to a character that has a valid default token with scopes, confirmed this shows in the logs and that the token is not replaced and stays valid:
```[2025-07-11T18:53:06.811345+00:00] app.DEBUG: Account::updateAndStoreCharacterWithPlayer: Skipped updating token for 2113459487 because it would replace a valid token with a no-scopes token.```

Also attempted scenarios where the token update should not be skipped (e.g. invalid revoked token, new account, etc) and confirm the log message does not show and the new token is stored.

### Automatic

Added a new unit test (and ran existing tests):
```/app/backend $ composer test
PHPUnit 10.5.46 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.4.10
Configuration: /app/backend/phpunit.xml

.............S...............................................   61 / 1369 (  4%)
.............................................................  122 / 1369 (  8%)
.............................................................  183 / 1369 ( 13%)
.............................................................  244 / 1369 ( 17%)
.............................................................  305 / 1369 ( 22%)
.............................................................  366 / 1369 ( 26%)
.............................................................  427 / 1369 ( 31%)
.............................................................  488 / 1369 ( 35%)
.............................................................  549 / 1369 ( 40%)
.............................................................  610 / 1369 ( 44%)
.............................................................  671 / 1369 ( 49%)
.............................................................  732 / 1369 ( 53%)
.............................................................  793 / 1369 ( 57%)
.............................................................  854 / 1369 ( 62%)
.............................................................  915 / 1369 ( 66%)
.............................................................  976 / 1369 ( 71%)
............................................................. 1037 / 1369 ( 75%)
............................................................. 1098 / 1369 ( 80%)
............................................................. 1159 / 1369 ( 84%)
............................................................. 1220 / 1369 ( 89%)
............................................................. 1281 / 1369 ( 93%)
............................................................. 1342 / 1369 ( 98%)
...........................                                   1369 / 1369 (100%)

Time: 01:29.584, Memory: 96.50 MB

There was 1 skipped test:

1) Tests\Functional\Command\DBVerifySSLTest::testExecute
Does not apply to SQLite.

OK, but some tests were skipped!
Tests: 1369, Assertions: 3904, Skipped: 1.```